### PR TITLE
Fixed craftcms/cms requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "yii2"
   ],
   "require": {
-    "craftcms/cms": "~3.0.0-RC1",
+    "craftcms/cms": "^3.0.0-RC1",
     "flipboxdigital/swiftmailer-postmark": "^3.0"
   },
   "require-dev": {


### PR DESCRIPTION
Without this change, the plugin is saying it won’t be compatible with Craft 3.1+, which probably isn’t want you intended.